### PR TITLE
Feature/stdout fidelity

### DIFF
--- a/cargo-lens/src/main.rs
+++ b/cargo-lens/src/main.rs
@@ -12,49 +12,20 @@ use tui::{
     Frame, Terminal,
 };
 
-use crate::diagnostics::{CargoDispatcher, DiagnosticImport};
-
-#[macro_export]
-macro_rules! print {
-    ($($arg:tt)*) => {
-        #[cfg(feature = "debug_socket")]
-        std::eprint!($($arg)*);
-    };
-}
-
-#[macro_export]
-macro_rules! println {
-    ($($arg:tt)*) => {
-        #[cfg(feature = "debug_socket")]
-        std::eprintln!($($arg)*);
-    };
-}
-#[macro_export]
-macro_rules! eprint {
-    ($($arg:tt)*) => {
-        #[cfg(feature = "debug_socket")]
-        std::eprint!($($arg)*);
-    };
-}
-
-#[macro_export]
-macro_rules! eprintln {
-    ($($arg:tt)*) => {
-        #[cfg(feature = "debug_socket")]
-        std::eprintln!($($arg)*);
-    };
-}
-
 #[cfg(feature = "debug_socket")]
 mod debug;
 mod diagnostics;
+mod print_macros;
 mod review_req_checklist;
+
+use crate::diagnostics::{CargoDispatcher, DiagnosticImport};
+
 fn main() -> Result<(), Box<dyn Error>> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "debug_socket")] {
             std::println!("listening on localhost:8080 for external debugger connection...");
             let _debug_out = { debug::connect_to_iface() }?;
-            std::println("`println!` disabled. stdout redirected to localhost:8080");
+            std::println!("`println!` disabled. stdout redirected to localhost:8080");
         } else {
             std::println!("println! and eprintln! disabled. stdout and the tui are now in an exclusive relationship.");
         }

--- a/cargo-lens/src/main.rs
+++ b/cargo-lens/src/main.rs
@@ -15,6 +15,8 @@ use tui::{
 #[cfg(feature = "debug_socket")]
 mod debug;
 mod diagnostics;
+/// Overrides std-provided print macros so it doesn't interfere with the terminal.
+/// To use the std-print macros, call with `std::[e]print[ln]!`
 mod print_macros;
 mod review_req_checklist;
 
@@ -59,7 +61,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err);
+        std::eprintln!("{:?}", err);
     }
 
     Ok(())

--- a/cargo-lens/src/main.rs
+++ b/cargo-lens/src/main.rs
@@ -17,23 +17,31 @@ use crate::diagnostics::{CargoDispatcher, DiagnosticImport};
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {
-        {
-            #[cfg(feature = "debug_socket")]
-            let _ = std::io::stderr().write_fmt(format_args!($($arg)*)).unwrap();
-        }
+        #[cfg(feature = "debug_socket")]
+        std::eprint!($($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! println {
-    () => {
-        print!("\n")
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprintln!($($arg)*);
     };
-    ($fmt:expr) => {
-        print!(concat!($fmt, "\n"))
+}
+#[macro_export]
+macro_rules! eprint {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprint!($($arg)*);
     };
-    ($fmt:expr, $($arg:tt)*) => {
-        print!(concat!($fmt, "\n"), $($arg)*)
+}
+
+#[macro_export]
+macro_rules! eprintln {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprintln!($($arg)*);
     };
 }
 
@@ -41,14 +49,14 @@ macro_rules! println {
 mod debug;
 mod diagnostics;
 mod review_req_checklist;
-
 fn main() -> Result<(), Box<dyn Error>> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "debug_socket")] {
-            eprintln!("waiting for external debugger connection...");
+            std::println!("listening on localhost:8080 for external debugger connection...");
             let _debug_out = { debug::connect_to_iface() }?;
+            std::println("`println!` disabled. stdout redirected to localhost:8080");
         } else {
-            // TODO: somehow sanatise stdin/err/out for final product
+            std::println!("println! and eprintln! disabled. stdout and the tui are now in an exclusive relationship.");
         }
     }
 

--- a/cargo-lens/src/main.rs
+++ b/cargo-lens/src/main.rs
@@ -14,6 +14,29 @@ use tui::{
 
 use crate::diagnostics::{CargoDispatcher, DiagnosticImport};
 
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        {
+            #[cfg(feature = "debug_socket")]
+            let _ = std::io::stderr().write_fmt(format_args!($($arg)*)).unwrap();
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! println {
+    () => {
+        print!("\n")
+    };
+    ($fmt:expr) => {
+        print!(concat!($fmt, "\n"))
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        print!(concat!($fmt, "\n"), $($arg)*)
+    };
+}
+
 #[cfg(feature = "debug_socket")]
 mod debug;
 mod diagnostics;

--- a/cargo-lens/src/print_macros.rs
+++ b/cargo-lens/src/print_macros.rs
@@ -1,0 +1,30 @@
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprint!($($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprintln!($($arg)*);
+    };
+}
+#[macro_export]
+macro_rules! eprint {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprint!($($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! eprintln {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug_socket")]
+        std::eprintln!($($arg)*);
+    };
+}


### PR DESCRIPTION
the terminal running the tui needs to be used exclusively by the tui, otherwise it mangels the rendering. This PR optionally waits until it hass a tcp stream it can connect to, and redirects std err there, and mangles `println` so that it is either o no-op, or uses `eprintln!` instead, if we are setting up with debug_stream.